### PR TITLE
Add lat and lng to toot based on v1.3.2

### DIFF
--- a/.env.production.sample
+++ b/.env.production.sample
@@ -90,3 +90,6 @@ SMTP_FROM_ADDRESS=notifications@example.com
 # Cluster number setting for streaming API server.
 # If you comment out following line, cluster number will be `numOfCpuCores - 1`.
 STREAMING_CLUSTER_NUM=1
+
+# Google Maps API key.
+# GMAP_KEY=

--- a/app/assets/javascripts/components/actions/compose.jsx
+++ b/app/assets/javascripts/components/actions/compose.jsx
@@ -81,7 +81,8 @@ export function submitCompose() {
     let visibility = getState().getIn(['compose', 'privacy']);
     if (visibility == 'geo') {
       if (!navigator.geolocation){
-        console.log("navigator.geolocation is not supported.");
+        alert('Geolocation is not supported for this browser.');
+        return;
       } else {
         navigator.geolocation.getCurrentPosition(
           function(position){
@@ -117,7 +118,10 @@ export function submitCompose() {
               dispatch(submitComposeFail(error));
             });
           },
-          function(error){ console.log('Error', error); }
+          function(error){
+            console.log('navigator.geolocation error', error);
+            dispatch(submitComposeFail(error));
+          }
         );
       }
     } else {

--- a/app/assets/javascripts/components/actions/compose.jsx
+++ b/app/assets/javascripts/components/actions/compose.jsx
@@ -78,35 +78,46 @@ export function submitCompose() {
       return;
     }
     dispatch(submitComposeRequest());
-    api(getState).post('/api/v1/statuses', {
-      status,
-      in_reply_to_id: getState().getIn(['compose', 'in_reply_to'], null),
-      media_ids: getState().getIn(['compose', 'media_attachments']).map(item => item.get('id')),
-      sensitive: getState().getIn(['compose', 'sensitive']),
-      spoiler_text: getState().getIn(['compose', 'spoiler_text'], ''),
-      visibility: getState().getIn(['compose', 'privacy'])
-    }, {
-      headers: {
-        'Idempotency-Key': getState().getIn(['compose', 'idempotencyKey'])
-      }
-    }).then(function (response) {
-      dispatch(submitComposeSuccess({ ...response.data }));
+    if (!navigator.geolocation){
+      console.log("navigator.geolocation is not supported.");
+    } else {
+      navigator.geolocation.getCurrentPosition(
+        function(position){
+          api(getState).post('/api/v1/statuses', {
+            status,
+            in_reply_to_id: getState().getIn(['compose', 'in_reply_to'], null),
+            media_ids: getState().getIn(['compose', 'media_attachments']).map(item => item.get('id')),
+            sensitive: getState().getIn(['compose', 'sensitive']),
+            spoiler_text: getState().getIn(['compose', 'spoiler_text'], ''),
+            visibility: getState().getIn(['compose', 'privacy']),
+            lon: position.coords.longitude,
+            lat: position.coords.latitude
+          }, {
+            headers: {
+              'Idempotency-Key': getState().getIn(['compose', 'idempotencyKey'])
+            }
+          }).then(function (response) {
+            dispatch(submitComposeSuccess({ ...response.data }));
 
-      // To make the app more responsive, immediately get the status into the columns
-      dispatch(updateTimeline('home', { ...response.data }));
+            // To make the app more responsive, immediately get the status into the columns
+            dispatch(updateTimeline('home', { ...response.data }));
 
-      if (response.data.in_reply_to_id === null && response.data.visibility === 'public') {
-        if (getState().getIn(['timelines', 'community', 'loaded'])) {
-          dispatch(updateTimeline('community', { ...response.data }));
-        }
+            if (response.data.in_reply_to_id === null && response.data.visibility === 'public') {
+              if (getState().getIn(['timelines', 'community', 'loaded'])) {
+                dispatch(updateTimeline('community', { ...response.data }));
+              }
 
-        if (getState().getIn(['timelines', 'public', 'loaded'])) {
-          dispatch(updateTimeline('public', { ...response.data }));
-        }
-      }
-    }).catch(function (error) {
-      dispatch(submitComposeFail(error));
-    });
+              if (getState().getIn(['timelines', 'public', 'loaded'])) {
+                dispatch(updateTimeline('public', { ...response.data }));
+              }
+            }
+          }).catch(function (error) {
+            dispatch(submitComposeFail(error));
+          });
+        },
+        function(error){ console.log('Error', error); }
+      );
+    }
   };
 };
 

--- a/app/assets/javascripts/components/components/status_content.jsx
+++ b/app/assets/javascripts/components/components/status_content.jsx
@@ -88,7 +88,16 @@ class StatusContent extends React.PureComponent {
     const { status } = this.props;
     const { hidden } = this.state;
 
-    const content = { __html: emojify(status.get('content')) };
+    let map = ''
+    let lat = status.get('lat');
+    let lon = status.get('lon');
+    if (lat && lon) {
+      map = "<a href='https://maps.google.co.jp/maps?q=" + lat + "," + lon + "' target='_blank'><img src='" +
+        "https://maps.googleapis.com/maps/api/staticmap?center=" + lat + "%2C" + lon +
+        "&markers=color%3Ared%7Csize%3Amid%7C" + lat + "%2C" + lon +
+        "&zoom=15&size=200x100&sensor=false&key=" + window.gmapKey + "'></a>"
+    }
+    const content = { __html: emojify(status.get('content')) + map };
     const spoilerContent = { __html: emojify(escapeTextContentForBrowser(status.get('spoiler_text', ''))) };
     const directionStyle = { direction: 'ltr' };
 

--- a/app/assets/javascripts/components/containers/mastodon.jsx
+++ b/app/assets/javascripts/components/containers/mastodon.jsx
@@ -223,9 +223,13 @@ Container.propTypes = {
 class Mastodon extends React.Component {
 
   componentDidMount() {
-    const { locale }  = this.props;
+    const { locale, gmapKey }  = this.props;
     const streamingAPIBaseURL = store.getState().getIn(['meta', 'streaming_api_base_url']);
     const accessToken = store.getState().getIn(['meta', 'access_token']);
+
+    // FIXME
+    // Better way to set as a global constant.
+    window.gmapKey = gmapKey;
 
     this.subscription = createStream(streamingAPIBaseURL, accessToken, 'user', {
 

--- a/app/assets/javascripts/components/features/compose/components/privacy_dropdown.jsx
+++ b/app/assets/javascripts/components/features/compose/components/privacy_dropdown.jsx
@@ -3,6 +3,8 @@ import { injectIntl, defineMessages } from 'react-intl';
 import IconButton from '../../../components/icon_button';
 
 const messages = defineMessages({
+  geo_short: { id: 'privacy.geo.short', defaultMessage: 'Location' },
+  geo_long: { id: 'privacy.geo.long', defaultMessage: 'Post to public timelines with location info' },
   public_short: { id: 'privacy.public.short', defaultMessage: 'Public' },
   public_long: { id: 'privacy.public.long', defaultMessage: 'Post to public timelines' },
   unlisted_short: { id: 'privacy.unlisted.short', defaultMessage: 'Unlisted' },
@@ -67,6 +69,7 @@ class PrivacyDropdown extends React.PureComponent {
     const { open } = this.state;
 
     const options = [
+      { icon: 'map-marker', value: 'geo', shortText: intl.formatMessage(messages.geo_short), longText: intl.formatMessage(messages.geo_long) },
       { icon: 'globe', value: 'public', shortText: intl.formatMessage(messages.public_short), longText: intl.formatMessage(messages.public_long) },
       { icon: 'unlock-alt', value: 'unlisted', shortText: intl.formatMessage(messages.unlisted_short), longText: intl.formatMessage(messages.unlisted_long) },
       { icon: 'lock', value: 'private', shortText: intl.formatMessage(messages.private_short), longText: intl.formatMessage(messages.private_long) },

--- a/app/assets/javascripts/components/locales/ja.jsx
+++ b/app/assets/javascripts/components/locales/ja.jsx
@@ -125,6 +125,8 @@ const ja = {
   "privacy.public.short": "公開",
   "privacy.unlisted.long": "公開TLで表示しない",
   "privacy.unlisted.short": "未収載",
+  "privacy.geo.long": "公開TLに位置情報付きで投稿する",
+  "privacy.geo.short": "公開(位置情報付き)",
   "reply_indicator.cancel": "キャンセル",
   "report.heading": "新規通報",
   "report.placeholder": "コメント",

--- a/app/controllers/api/v1/statuses_controller.rb
+++ b/app/controllers/api/v1/statuses_controller.rb
@@ -65,8 +65,9 @@ class Api::V1::StatusesController < ApiController
                                          spoiler_text: status_params[:spoiler_text],
                                          visibility: status_params[:visibility],
                                          application: doorkeeper_token.application,
-                                         idempotency: request.headers['Idempotency-Key'])
-
+                                         idempotency: request.headers['Idempotency-Key'],
+                                         lon: status_params[:lon],
+                                         lat: status_params[:lat])
     render :show
   end
 
@@ -113,7 +114,7 @@ class Api::V1::StatusesController < ApiController
   end
 
   def status_params
-    params.permit(:status, :in_reply_to_id, :sensitive, :spoiler_text, :visibility, media_ids: [])
+    params.permit(:status, :in_reply_to_id, :sensitive, :spoiler_text, :visibility, :lon, :lat, media_ids: [])
   end
 
   def pagination_params(core_params)

--- a/app/helpers/home_helper.rb
+++ b/app/helpers/home_helper.rb
@@ -4,6 +4,7 @@ module HomeHelper
   def default_props
     {
       locale: I18n.locale,
+      gmapKey: Rails.configuration.x.gmap_key,
     }
   end
 end

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -5,7 +5,7 @@ class Status < ApplicationRecord
   include Streamable
   include Cacheable
 
-  enum visibility: [:public, :unlisted, :private, :direct], _suffix: :visibility
+  enum visibility: [:geo, :public, :unlisted, :private, :direct], _suffix: :visibility
 
   belongs_to :application, class_name: 'Doorkeeper::Application'
 

--- a/app/services/post_status_service.rb
+++ b/app/services/post_status_service.rb
@@ -28,6 +28,8 @@ class PostStatusService < BaseService
                                         spoiler_text: options[:spoiler_text] || '',
                                         visibility: options[:visibility],
                                         language: detect_language_for(text, account),
+                                        lat: options[:lat],
+                                        lon: options[:lon],
                                         application: options[:application])
       attach_media(status, media)
     end

--- a/app/views/api/v1/statuses/_show.rabl
+++ b/app/views/api/v1/statuses/_show.rabl
@@ -5,6 +5,8 @@ node(:content)          { |status| Formatter.instance.format(status) }
 node(:url)              { |status| TagManager.instance.url_for(status) }
 node(:reblogs_count)    { |status| defined?(@reblogs_counts_map)    ? (@reblogs_counts_map[status.id]    || 0) : status.reblogs_count }
 node(:favourites_count) { |status| defined?(@favourites_counts_map) ? (@favourites_counts_map[status.id] || 0) : status.favourites_count }
+node(:lon)              { |status| status.lon }
+node(:lat)              { |status| status.lat }
 
 child :application do
   extends 'api/v1/apps/show'

--- a/config/initializers/gmap_key.rb
+++ b/config/initializers/gmap_key.rb
@@ -1,0 +1,3 @@
+Rails.application.configure do
+  config.x.gmap_key = ENV.fetch('GMAP_KEY') { '' }
+end

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -315,6 +315,8 @@ ja:
       public_long: 誰でも見ることができ、かつ公開タイムラインに表示されます
       unlisted: 未収載
       unlisted_long: 誰でも見ることができますが、公開タイムラインには表示されません
+      geo: 公開(位置情報付き)
+      geo_long: 誰でも見ることができ、かつ位置情報付きで公開タイムラインに表示されます
   stream_entries:
     click_to_show: クリックして表示
     reblogged: ブーストされました

--- a/db/migrate/20170428151212_add_lat_lon_to_statuses.rb
+++ b/db/migrate/20170428151212_add_lat_lon_to_statuses.rb
@@ -1,0 +1,6 @@
+class AddLatLonToStatuses < ActiveRecord::Migration[5.0]
+  def change
+    add_column :statuses, :lat, :decimal, :precision => 17, :scale => 14
+    add_column :statuses, :lon, :decimal, :precision => 17, :scale => 14
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170425202925) do
+ActiveRecord::Schema.define(version: 20170428151212) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -255,6 +255,8 @@ ActiveRecord::Schema.define(version: 20170425202925) do
     t.integer  "favourites_count",       default: 0,     null: false
     t.integer  "reblogs_count",          default: 0,     null: false
     t.string   "language",               default: "en",  null: false
+    t.decimal  "lat",                    precision: 17, scale: 14
+    t.decimal  "lon",                    precision: 17, scale: 14
     t.index ["account_id"], name: "index_statuses_on_account_id", using: :btree
     t.index ["in_reply_to_id"], name: "index_statuses_on_in_reply_to_id", using: :btree
     t.index ["reblog_of_id"], name: "index_statuses_on_reblog_of_id", using: :btree


### PR DESCRIPTION
# 使い方

位置情報が付いたTootができます。

Version 1.3.2のコードをベースにしています。

Tootの公開設定で、公開(位置情報付き)を選んでTootすると発言に位置情報が付きます。

<img width="290" alt="2017-04-28 19 20 31" src="https://cloud.githubusercontent.com/assets/10215/25554376/d5fdb1a4-2d06-11e7-81dc-4232fc8efbde.png">

地図が表示されます。

<img width="362" alt="2017-04-28 19 19 20" src="https://cloud.githubusercontent.com/assets/10215/25554397/58a6f58e-2d07-11e7-901a-018e6df2ba6f.png">

東京都調布市内在住者・通学者・勤務者及び調布好きな人のためのMastodon、チョウフドンで試すことができます。

&raquo; [チョウフドン](https://chofudon.tokyo)

# インストール方法

## 新規インストール

git cloneでtootsuite/mastodonを取得する代わりに、champierre/mastodonを取得する。

```
% git clone git@github.com:champierre/mastodon.git
% git checkout feature/add_lat_lng_to_toot
```

.env.sample.productionを.env.productionにコピーしたあと、ファイル末尾の

```
# GMAP_KEY=
```

に[Google API Console](https://console.developers.google.com/)より取得できるGoogle Maps API Keyをセットします。

あとは、Mastodonの通常のセットアップと同様です。

## 既存のソースを入れ替える場合

git@github.com:champierre/mastodon.git のソースに入れ替え、.env.productionにGoogle Maps API キーをセットしたあと(「新規インストール」の項目参照)、

```
% docker-compose build
% docker-compose run --rm web rake db:migrate
% docker-compose run --rm web yarn install --pure-lockfile
% docker-compose run --rm web rake assets:precompile
% docker-compose stop
% docker-compose up -d
% sudo service nginx restart
```

が必要です。

[参考] https://github.com/tootsuite/documentation/blob/master/Running-Mastodon/Docker-Guide.md の「Updating」の項目

